### PR TITLE
include missing win32 libraries for linker when using static built op…

### DIFF
--- a/generic/build
+++ b/generic/build
@@ -397,6 +397,13 @@ if [ -n "${BUILD_FOR_WINDOWS}" ]; then
 		${CONFIGOPTS} \
 		--sbindir=/bin \
 	"
+	if [ -n "${DO_STATIC}" ]; then
+		OPENSSL_LIBS=" \
+			${OPENSSL_LIBS} \
+			-lws2_32 \
+			-lgdi32 \
+		"
+	fi
 	export PKG_CONFIG="true"
 fi
 


### PR DESCRIPTION
…enssl